### PR TITLE
Add images to Products 

### DIFF
--- a/backend/main/schema/inputs.py
+++ b/backend/main/schema/inputs.py
@@ -22,3 +22,7 @@ class ProductOfferInput(graphene.InputObjectType):
 class UserReportInput(graphene.InputObjectType):
     reported_user = graphene.String()
     category = graphene.Int()
+
+class UploadImageInput(graphene.InputObjectType):
+    product_id = graphene.Int()
+

--- a/backend/main/schema/mutation.py
+++ b/backend/main/schema/mutation.py
@@ -34,7 +34,6 @@ class MutationPayload(graphene.ObjectType):
 class CreateProduct(MutationPayload, graphene.Mutation):
     class Arguments:
         input = ProductInput()
-        file = Upload(required=False)
 
     product = graphene.Field(Product)
 
@@ -43,10 +42,7 @@ class CreateProduct(MutationPayload, graphene.Mutation):
     def mutate(root, info, input=None):
         errors = []
 
-        files = info.context.FILES
-
         seller = info.context.user.profile
-        product = utils.create_product(seller, files, **input.__dict__)
         viewlog.debug(f"Product created with details : {product.to_dict()}")
 
         return CreateProduct(errors=errors,product=product)

--- a/backend/main/schema/mutation.py
+++ b/backend/main/schema/mutation.py
@@ -3,11 +3,13 @@ import logging
 import graphene
 from django.core.exceptions import ObjectDoesNotExist
 from graphql_jwt.decorators import login_required, user_passes_test
+from graphene_file_upload.scalars import Upload
 
 from main import models
 from main.schema import utils
 from main.schema.inputs import (ProductInput, ProductOfferInput,
-                                ProfileUpdateInput, UserReportInput)
+                                ProfileUpdateInput, UserReportInput,
+                                UploadImageInput)
 from main.schema.types import (Product, ProductOffer, Profile, UserReport,
                                Wishlist)
 
@@ -32,6 +34,7 @@ class MutationPayload(graphene.ObjectType):
 class CreateProduct(MutationPayload, graphene.Mutation):
     class Arguments:
         input = ProductInput()
+        file = Upload(required=False)
 
     product = graphene.Field(Product)
 
@@ -40,8 +43,10 @@ class CreateProduct(MutationPayload, graphene.Mutation):
     def mutate(root, info, input=None):
         errors = []
 
+        files = info.context.FILES
+
         seller = info.context.user.profile
-        product = utils.create_product(seller, **input.__dict__)
+        product = utils.create_product(seller, files, **input.__dict__)
         viewlog.debug(f"Product created with details : {product.to_dict()}")
 
         return CreateProduct(errors=errors,product=product)
@@ -195,6 +200,37 @@ class CreateUserReport(MutationPayload, graphene.Mutation):
 
         return CreateUserReport(errors=errors, user_report=user_report)
 
+class UploadImage(MutationPayload, graphene.Mutation):
+    class Arguments:
+        input = UploadImageInput()
+        file = Upload(required=False)
+
+    product = graphene.Field(Product)
+
+    @login_required
+    @user_passes_test(lambda user: user.profile.permission_level >= models.Profile.SELLER)
+    def mutate(root, info, input=None):
+        errors = []
+        id = input.get('product_id')
+        # id = input.get('product_id')
+
+        try:
+            product = models.Product.objects.get(id=id)
+        except ObjectDoesNotExist:
+            errors.append(f"Product with primary key {id} does not exist.")
+            return UploadImage(errors=errors, product=None)
+
+        if product.seller != info.context.user.profile:
+            errors.append("You are not allowed to perform this action.")
+            return UploadImage(errors=errors, product=None)
+
+        files = info.context.FILES
+
+        product = utils.add_images_to_product(files, id)
+        viewlog.debug(f"Product created with details : {product.to_dict()}")
+
+        return UploadImage(errors=errors,product=product)
+
 # class UpdateOffer(MutationPayload, graphene.Mutation):
 #     class Arguments:
 #         id = graphene.Int(required=True)
@@ -227,4 +263,5 @@ class Mutation:
     update_wishlist = UpdateWishlist.Field()
     create_offer = CreateOffer.Field()
     create_user_report = CreateUserReport.Field()
+    upload_image = UploadImage.Field()
     # update_offer = UpdateOffer.Field()

--- a/backend/main/schema/utils.py
+++ b/backend/main/schema/utils.py
@@ -21,9 +21,9 @@ def get_paginator(qs, page_size, page, paginated_type, **kwargs):
     )
 
     
-def create_product(seller, **kwargs, ):
+def create_product(seller, files, **kwargs, ):
     """
-        Given the attributes of a product and a Profile(seller) instance, create a new product and save it to the database. Utility for the CreateProduct mutation. 
+        Given the attributes of a product and images and a Profile(seller) instance, create a new product and save it with respective ImageModels' to the database. Utility for the CreateProduct mutation. 
     """
 
     p = models.Product()
@@ -33,6 +33,7 @@ def create_product(seller, **kwargs, ):
     p.is_negotiable = kwargs.get('is_negotiable')
     p.description = kwargs.get('description')
     p.category_id = kwargs.get('category_id')
+
     p.save()
 
     return p
@@ -109,7 +110,20 @@ def create_user_report(reported_by, **kwargs):
 
     return report
 
-
+def add_images_to_product(files, id):
+    """
+        Given the attributes of a Product and its related images, create new ImageModels' and add them to respective images attribute of the respective Product
+    """
+    product = models.Product.objects.get(id=id)
+    if len(files.keys()) != 0:
+        for i in files.keys():
+            print(files.keys())
+            imag = models.ImageModel()
+            imag.image = files[i]
+            imag.save()
+            product.images.add(imag)
+    product.save()
+    return product
 # def update_offer(offer, **kwargs):
 
 #     fields = ['amount', 'message']

--- a/backend/main/urls.py
+++ b/backend/main/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
+from graphene_file_upload.django import FileUploadGraphQLView
 
 from marketplace.schema import schema
 
@@ -8,6 +9,6 @@ from .views import auth, content, index
 
 urlpatterns = [
     path("", index.index, name="index"),
-    path("api/graphql/", csrf_exempt(GraphQLView.as_view(graphiql=True, schema=schema))),
+    path("api/graphql/", csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True, schema=schema))),
     path("auth/authenticate/", auth.authenticate, name="auth-authenticate"),
 ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,6 +34,7 @@ google-resumable-media==0.5.0
 googleapis-common-protos==1.51.0
 graphene==2.1.8
 graphene-django==2.9.1
+graphene-file-upload==1.2.2
 graphql-core==2.3.1
 graphql-relay==2.0.1
 gunicorn==20.0.4


### PR DESCRIPTION
Functionality for adding images to the respective Product has been added. For achieving this functionality a new python package 'graphene-file-upload' was used. In order to achieve this functionality in urls.py, The GraphQL View had to be replaced with GraphQLFileView also a new UploadImage was created and a similar utility function was added to utils.py.
A Sample Mutation to upload Files may look as follows:

###UploadImage Mutation
query_string = '''
    mutation($prodId : Int! ) {
    uploadImage(input: { productId: $prodId }) {
        ok
        }
    }
    '''
A query string of the above format would help one to make a regular upload. Here 'prodId' is a variable in the query_string to denote the product to which the images have to be assigned. With this as a multi-part request, we are sending the relevant product ID as a query parameter. Relevant single or multiple file/s should be passed along with the respective multi-part request.
